### PR TITLE
HTTP Response Interface

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,226 @@
+---
+Language:        Cpp
+BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: NextLine
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: pb
+    BasedOnStyle:    google
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,58 @@
+---
+Checks:          "clang-diagnostic-* \
+                  , clang-analyzer-* \
+                  , bugprone-* \
+                  , cert-* \
+                  , cppcoreguidelines-* \
+                  , google-* \
+                  , llvm-* \
+                  , performance-* \
+                  , readability-* \
+                  , -readability-magic-numbers \
+                  , -cppcoreguidelines-avoid-magic-numbers \
+                  "
+
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     file
+User:            root
+CheckOptions:
+  - key:             llvm-else-after-return.WarnOnConditionVariables
+    value:           'false'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
+    value:           'false'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             cert-err33-c.CheckedFunctions
+    value:           '::aligned_alloc;::asctime_s;::at_quick_exit;::atexit;::bsearch;::bsearch_s;::btowc;::c16rtomb;::c32rtomb;::calloc;::clock;::cnd_broadcast;::cnd_init;::cnd_signal;::cnd_timedwait;::cnd_wait;::ctime_s;::fclose;::fflush;::fgetc;::fgetpos;::fgets;::fgetwc;::fopen;::fopen_s;::fprintf;::fprintf_s;::fputc;::fputs;::fputwc;::fputws;::fread;::freopen;::freopen_s;::fscanf;::fscanf_s;::fseek;::fsetpos;::ftell;::fwprintf;::fwprintf_s;::fwrite;::fwscanf;::fwscanf_s;::getc;::getchar;::getenv;::getenv_s;::gets_s;::getwc;::getwchar;::gmtime;::gmtime_s;::localtime;::localtime_s;::malloc;::mbrtoc16;::mbrtoc32;::mbsrtowcs;::mbsrtowcs_s;::mbstowcs;::mbstowcs_s;::memchr;::mktime;::mtx_init;::mtx_lock;::mtx_timedlock;::mtx_trylock;::mtx_unlock;::printf_s;::putc;::putwc;::raise;::realloc;::remove;::rename;::scanf;::scanf_s;::setlocale;::setvbuf;::signal;::snprintf;::snprintf_s;::sprintf;::sprintf_s;::sscanf;::sscanf_s;::strchr;::strerror_s;::strftime;::strpbrk;::strrchr;::strstr;::strtod;::strtof;::strtoimax;::strtok;::strtok_s;::strtol;::strtold;::strtoll;::strtoul;::strtoull;::strtoumax;::strxfrm;::swprintf;::swprintf_s;::swscanf;::swscanf_s;::thrd_create;::thrd_detach;::thrd_join;::thrd_sleep;::time;::timespec_get;::tmpfile;::tmpfile_s;::tmpnam;::tmpnam_s;::tss_create;::tss_get;::tss_set;::ungetc;::ungetwc;::vfprintf;::vfprintf_s;::vfscanf;::vfscanf_s;::vfwprintf;::vfwprintf_s;::vfwscanf;::vfwscanf_s;::vprintf_s;::vscanf;::vscanf_s;::vsnprintf;::vsnprintf_s;::vsprintf;::vsprintf_s;::vsscanf;::vsscanf_s;::vswprintf;::vswprintf_s;::vswscanf;::vswscanf_s;::vwprintf_s;::vwscanf;::vwscanf_s;::wcrtomb;::wcschr;::wcsftime;::wcspbrk;::wcsrchr;::wcsrtombs;::wcsrtombs_s;::wcsstr;::wcstod;::wcstof;::wcstoimax;::wcstok;::wcstok_s;::wcstol;::wcstold;::wcstoll;::wcstombs;::wcstombs_s;::wcstoul;::wcstoull;::wcstoumax;::wcsxfrm;::wctob;::wctrans;::wctype;::wmemchr;::wprintf_s;::wscanf;::wscanf_s;'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           'false'
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           'true'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             llvm-qualified-auto.AddConstToQualified
+    value:           'false'
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             llvm-else-after-return.WarnOnUnfixable
+    value:           'false'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+...
+

--- a/include/http_request.cc
+++ b/include/http_request.cc
@@ -14,7 +14,7 @@ void HttpRequest::ParseRequest(const std::string& raw_request) {
     // input is a raw http request
     // format: 
     //
-    // GET /path HTTP/1.1\r\n
+    // GET /path HTTP/1.0\r\n
     // Host: localhost:8080\r\n
     // Content-Type: application/json\r\n
     // Content-Length: 36\r\n
@@ -52,14 +52,16 @@ void HttpRequest::ParseRequest(const std::string& raw_request) {
 }
 
 void HttpRequest::ParseRequestLine(const std::string& req_line) {
-    // format: GET /path HTTP/1.1
+    // format: GET /path HTTP/1.0
 
     std::istringstream iss(req_line);
     std::string method, path, version;
     iss >> method >> path >> version;
+    if (version != "HTTP/1.0") {
+        throw std::invalid_argument("Invalid HTTP version");
+    }
     method_ = StringToMethod(method);
-    uri_.SetPath(path);
-    version_ = StringToVersion(version);
+    uri_.SetPath(path); 
 
     // std::cout << method << " " << path << " " << version << std::endl;
 }
@@ -118,18 +120,6 @@ HttpMethod HttpRequest::StringToMethod(const std::string& method) {
         return HttpMethod::PATCH;
     } else {
         throw std::invalid_argument("Invalid HTTP method");
-    }
-}
-
-HttpVersion HttpRequest::StringToVersion(const std::string& version) {
-    if (version == "HTTP/1.0") {
-        return HttpVersion::HTTP_1_0;
-    } else if (version == "HTTP/1.1") {
-        return HttpVersion::HTTP_1_1;
-    } else if (version == "HTTP/2.0") {
-        return HttpVersion::HTTP_2_0;
-    } else {
-        throw std::invalid_argument("Invalid HTTP version");
     }
 }
 

--- a/include/http_request.cc
+++ b/include/http_request.cc
@@ -61,7 +61,7 @@ void HttpRequest::ParseRequestLine(const std::string& req_line) {
         throw std::invalid_argument("Invalid HTTP version");
     }
     method_ = StringToMethod(method);
-    uri_.SetPath(path); 
+    uri_.set_path(path); 
 
     // std::cout << method << " " << path << " " << version << std::endl;
 }
@@ -88,8 +88,8 @@ void HttpRequest::ParseHeaders(const std::string& headers) {
             size_t pos = value.find(":");
             std::string host = value.substr(0, pos);
             std::string port = value.substr(pos + 1);
-            uri_.SetHost(host);
-            uri_.SetPort(port);
+            uri_.set_host(host);
+            uri_.set_port(port);
         }
 
         // std::cout << key << " " << value << std::endl;
@@ -124,4 +124,4 @@ HttpMethod HttpRequest::StringToMethod(const std::string& method) {
 }
 
 
-}
+} // namespace potion

--- a/include/http_request.cc
+++ b/include/http_request.cc
@@ -3,7 +3,6 @@
 #include <sstream>
 // #include <iostream>
 
-
 namespace potion {
 
 HttpRequest::HttpRequest(const std::string& raw_request) {
@@ -12,7 +11,7 @@ HttpRequest::HttpRequest(const std::string& raw_request) {
 
 void HttpRequest::ParseRequest(const std::string& raw_request) {
     // input is a raw http request
-    // format: 
+    // format:
     //
     // GET /path HTTP/1.0\r\n
     // Host: localhost:8080\r\n
@@ -20,10 +19,13 @@ void HttpRequest::ParseRequest(const std::string& raw_request) {
     // Content-Length: 36\r\n
     // \r\n
     // this is the request body
-    
-    std::string request_line, headers, body;
-    size_t start = 0, end = 0;
-    
+
+    std::string request_line;
+    std::string headers;
+    std::string body;
+    size_t start = 0;
+    size_t end = 0;
+
     // get request line
     end = raw_request.find("\r\n");
     request_line = raw_request.substr(start, end - start);
@@ -55,19 +57,21 @@ void HttpRequest::ParseRequestLine(const std::string& req_line) {
     // format: GET /path HTTP/1.0
 
     std::istringstream iss(req_line);
-    std::string method, path, version;
+    std::string method;
+    std::string path;
+    std::string version;
     iss >> method >> path >> version;
     if (version != "HTTP/1.0") {
         throw std::invalid_argument("Invalid HTTP version");
     }
     method_ = StringToMethod(method);
-    uri_.set_path(path); 
+    uri_.set_path(path);
 
     // std::cout << method << " " << path << " " << version << std::endl;
 }
 
 void HttpRequest::ParseHeaders(const std::string& headers) {
-    // format: 
+    // format:
     // Host: localhost:8080\r\n
     // Content-Type: application/json\r\n
     // Content-Length: 36\r\n
@@ -79,13 +83,13 @@ void HttpRequest::ParseHeaders(const std::string& headers) {
         line.erase(std::remove(line.begin(), line.end(), '\r'), line.end());
 
         // get key and value
-        size_t pos = line.find(":");
+        size_t pos = line.find(':');
         std::string key = line.substr(0, pos);
         std::string value = line.substr(pos + 2);
 
         // add host and port to uri
         if (key == "Host") {
-            size_t pos = value.find(":");
+            size_t pos = value.find(':');
             std::string host = value.substr(0, pos);
             std::string port = value.substr(pos + 1);
             uri_.set_host(host);
@@ -97,7 +101,6 @@ void HttpRequest::ParseHeaders(const std::string& headers) {
         headers_[key] = value;
     }
 }
-
 
 HttpMethod HttpRequest::StringToMethod(const std::string& method) {
     if (method == "GET") {
@@ -123,5 +126,4 @@ HttpMethod HttpRequest::StringToMethod(const std::string& method) {
     }
 }
 
-
-} // namespace potion
+}  // namespace potion

--- a/include/http_request.hh
+++ b/include/http_request.hh
@@ -25,8 +25,10 @@ enum class HttpMethod {
 class HttpRequest {
 public:
 
+// constructor
 HttpRequest(const std::string& raw_request);
 
+// accessors
 Uri uri() const { return uri_; }
 HttpMethod method() const { return method_; }
 std::string version() const { return "HTTP/1.0"; }
@@ -50,6 +52,6 @@ std::string body_;
 };
 
 
-}
+} // namespace potion
 
 #endif

--- a/include/http_request.hh
+++ b/include/http_request.hh
@@ -1,5 +1,5 @@
-#ifndef POTION_HTTP_H
-#define POTION_HTTP_H
+#ifndef POTION_HTTP_REQ_H
+#define POTION_HTTP_REQ_H
 
 #include "uri.hh"
 
@@ -21,13 +21,6 @@ enum class HttpMethod {
     PATCH
 };
 
-// might vause error bc HTTP_1_0 has same value as GET
-enum class HttpVersion {
-    HTTP_1_0,
-    HTTP_1_1,
-    HTTP_2_0
-};
-
 
 class HttpRequest {
 public:
@@ -36,7 +29,7 @@ HttpRequest(const std::string& raw_request);
 
 Uri uri() const { return uri_; }
 HttpMethod method() const { return method_; }
-HttpVersion version() const { return version_; }
+std::string version() const { return "HTTP/1.0"; }
 std::string body() const { return body_; }
 std::string header(const std::string& key) const { return headers_.at(key); }
 
@@ -47,12 +40,9 @@ void ParseRequestLine(const std::string& raw_request);
 void ParseHeaders(const std::string& raw_request);
 
 HttpMethod StringToMethod(const std::string& method);
-HttpVersion StringToVersion(const std::string& version);
-
 
 // members
 HttpMethod method_;
-HttpVersion version_;
 Uri uri_ = Uri();
 std::map<std::string, std::string> headers_;
 std::string body_;

--- a/include/http_request.hh
+++ b/include/http_request.hh
@@ -1,11 +1,11 @@
 #ifndef POTION_HTTP_REQ_H
 #define POTION_HTTP_REQ_H
 
-#include "uri.hh"
-
-#include <string>
 #include <map>
+#include <string>
 #include <type_traits>
+
+#include "uri.hh"
 
 namespace potion {
 
@@ -21,37 +21,34 @@ enum class HttpMethod {
     PATCH
 };
 
-
 class HttpRequest {
-public:
+   public:
+    // constructor
+    explicit HttpRequest(const std::string& raw_request);
 
-// constructor
-HttpRequest(const std::string& raw_request);
+    // accessors
+    Uri uri() const { return uri_; }
+    HttpMethod method() const { return method_; }
+    static std::string version() { return "HTTP/1.0"; }
+    std::string body() const { return body_; }
+    std::string header(const std::string& key) const {
+        return headers_.at(key);
+    }
 
-// accessors
-Uri uri() const { return uri_; }
-HttpMethod method() const { return method_; }
-std::string version() const { return "HTTP/1.0"; }
-std::string body() const { return body_; }
-std::string header(const std::string& key) const { return headers_.at(key); }
+   private:
+    void ParseRequest(const std::string& raw_request);
+    void ParseRequestLine(const std::string& req_line);
+    void ParseHeaders(const std::string& headers);
 
-private:
+    HttpMethod StringToMethod(const std::string& method);
 
-void ParseRequest(const std::string& raw_request);
-void ParseRequestLine(const std::string& raw_request);
-void ParseHeaders(const std::string& raw_request);
-
-HttpMethod StringToMethod(const std::string& method);
-
-// members
-HttpMethod method_;
-Uri uri_ = Uri();
-std::map<std::string, std::string> headers_;
-std::string body_;
-
+    // members
+    HttpMethod method_;
+    Uri uri_ = Uri();
+    std::map<std::string, std::string> headers_;
+    std::string body_;
 };
 
-
-} // namespace potion
+}  // namespace potion
 
 #endif

--- a/include/http_response.cc
+++ b/include/http_response.cc
@@ -2,101 +2,103 @@
 
 #include <sstream>
 
-
 namespace potion {
 
-// could make this a switch statement instead, not sure which one is faster when there are a lot of cases
-const std::unordered_map<unsigned int, std::string> HttpResponse::status_code_map_ = {
-    // ** 1xx Informational **
-    { 100,       "Continue" },
-    { 101,       "Switching Protocols" },
-    { 102,       "Processing" },
-    { 103,       "Early Hints" },
-    // ** 2xx Success **
-    { 200,       "OK" },
-    { 201,       "Created" },
-    { 202,       "Accepted" },
-    { 203,       "Non-Authoritative Information" },
-    { 204,       "No Content" },
-    { 205,       "Reset Content" },
-    { 206,       "Partial Content" },
-    { 207,       "Multi-Status" },
-    { 208,       "Already Reported" },
-    { 226,       "IM Used" },
-    // ** 3xx Redirection **
-    { 300,       "Multiple Choices" },
-    { 301,       "Moved Permanently" },
-    { 302,       "Found" },
-    { 303,       "See Other" },
-    { 304,       "Not Modified" },
-    { 305,       "Use Proxy" },
-    { 307,       "Temporary Redirect" },
-    { 308,       "Permanent Redirect" },
-    // ** 4xx Client Error **
-    { 400,       "Bad Request" },
-    { 401,       "Unauthorized" },
-    { 402,       "Payment Required" },
-    { 403,       "Forbidden" },
-    { 404,       "Not Found" },
-    { 405,       "Method Not Allowed" },
-    { 406,       "Not Acceptable" },
-    { 407,       "Proxy Authentication Required" },
-    { 408,       "Request Timeout" },
-    { 409,       "Conflict" },
-    { 410,       "Gone" },
-    { 411,       "Length Required" },
-    { 412,       "Precondition Failed" },
-    { 413,       "Payload Too Large" },
-    { 414,       "URI Too Long" },
-    { 415,       "Unsupported Media Type" },
-    { 416,       "Range Not Satisfiable" },
-    { 417,       "Expectation Failed" },
-    { 418,       "I'm a teapot" },
-    { 421,       "Misdirected Request" },
-    { 422,       "Unprocessable Entity" },
-    { 423,       "Locked" },
-    { 424,       "Failed Dependency" },
-    { 426,       "Upgrade Required" },
-    { 428,       "Precondition Required" },
-    { 429,       "Too Many Requests" },
-    { 431,       "Request Header Fields Too Large" },
-    { 444,       "Connection Closed Without Response" },
-    { 451,       "Unavailable For Legal Reasons" },
-    { 499,       "Client Closed Request" },
-    // ** 5xx Server Error **
-    { 500,       "Internal Server Error" },
-    { 501,       "Not Implemented" },
-    { 502,       "Bad Gateway" },
-    { 503,       "Service Unavailable" },
-    { 504,       "Gateway Timeout" },
-    { 505,       "HTTP Version Not Supported" },
-    { 506,       "Variant Also Negotiates" },
-    { 507,       "Insufficient Storage" },
-    { 508,       "Loop Detected" },
-    { 510,       "Not Extended" },
-    { 511,       "Network Authentication Required" },
-    { 500,       "Internal Server Error" },
-    { 501,       "Not Implemented" },
-    { 502,       "Bad Gateway" },
-    { 503,       "Service Unavailable" },
-    { 504,       "Gateway Timeout" },
-    { 505,       "HTTP Version Not Supported" },
-    { 506,       "Variant Also Negotiates" },
-    { 507,       "Insufficient Storage" },
-    { 508,       "Loop Detected" },
-    { 510,       "Not Extended" },
-    { 511,       "Network Authentication Required" },
+// could make this a switch statement instead, not sure which one is faster when
+// there are a lot of cases
+const std::unordered_map<unsigned int, std::string>
+    HttpResponse::status_code_map_ = {
+        // ** 1xx Informational **
+        {100, "Continue"},
+        {101, "Switching Protocols"},
+        {102, "Processing"},
+        {103, "Early Hints"},
+        // ** 2xx Success **
+        {200, "OK"},
+        {201, "Created"},
+        {202, "Accepted"},
+        {203, "Non-Authoritative Information"},
+        {204, "No Content"},
+        {205, "Reset Content"},
+        {206, "Partial Content"},
+        {207, "Multi-Status"},
+        {208, "Already Reported"},
+        {226, "IM Used"},
+        // ** 3xx Redirection **
+        {300, "Multiple Choices"},
+        {301, "Moved Permanently"},
+        {302, "Found"},
+        {303, "See Other"},
+        {304, "Not Modified"},
+        {305, "Use Proxy"},
+        {307, "Temporary Redirect"},
+        {308, "Permanent Redirect"},
+        // ** 4xx Client Error **
+        {400, "Bad Request"},
+        {401, "Unauthorized"},
+        {402, "Payment Required"},
+        {403, "Forbidden"},
+        {404, "Not Found"},
+        {405, "Method Not Allowed"},
+        {406, "Not Acceptable"},
+        {407, "Proxy Authentication Required"},
+        {408, "Request Timeout"},
+        {409, "Conflict"},
+        {410, "Gone"},
+        {411, "Length Required"},
+        {412, "Precondition Failed"},
+        {413, "Payload Too Large"},
+        {414, "URI Too Long"},
+        {415, "Unsupported Media Type"},
+        {416, "Range Not Satisfiable"},
+        {417, "Expectation Failed"},
+        {418, "I'm a teapot"},
+        {421, "Misdirected Request"},
+        {422, "Unprocessable Entity"},
+        {423, "Locked"},
+        {424, "Failed Dependency"},
+        {426, "Upgrade Required"},
+        {428, "Precondition Required"},
+        {429, "Too Many Requests"},
+        {431, "Request Header Fields Too Large"},
+        {444, "Connection Closed Without Response"},
+        {451, "Unavailable For Legal Reasons"},
+        {499, "Client Closed Request"},
+        // ** 5xx Server Error **
+        {500, "Internal Server Error"},
+        {501, "Not Implemented"},
+        {502, "Bad Gateway"},
+        {503, "Service Unavailable"},
+        {504, "Gateway Timeout"},
+        {505, "HTTP Version Not Supported"},
+        {506, "Variant Also Negotiates"},
+        {507, "Insufficient Storage"},
+        {508, "Loop Detected"},
+        {510, "Not Extended"},
+        {511, "Network Authentication Required"},
+        {500, "Internal Server Error"},
+        {501, "Not Implemented"},
+        {502, "Bad Gateway"},
+        {503, "Service Unavailable"},
+        {504, "Gateway Timeout"},
+        {505, "HTTP Version Not Supported"},
+        {506, "Variant Also Negotiates"},
+        {507, "Insufficient Storage"},
+        {508, "Loop Detected"},
+        {510, "Not Extended"},
+        {511, "Network Authentication Required"},
 };
 
-HttpResponse::HttpResponse(unsigned int status_code) {
-    status_code_ = status_code;
+HttpResponse::HttpResponse(unsigned int status_code)
+    : status_code_(status_code) {
     headers_["Content-Type"] = "text/html";
     headers_["Content-Length"] = "0";
 }
 
 std::string HttpResponse::ToString() {
     std::ostringstream oss;
-    oss << "HTTP/1.1 " << status_code_ << " " << status_code_map_.at(status_code_) << "\r\n";
+    oss << "HTTP/1.1 " << status_code_ << " "
+        << status_code_map_.at(status_code_) << "\r\n";
     for (auto& [key, value] : headers_) {
         oss << key << ": " << value << "\r\n";
     }
@@ -105,6 +107,4 @@ std::string HttpResponse::ToString() {
     return oss.str();
 }
 
-
-
-} // namespace potion
+}  // namespace potion

--- a/include/http_response.cc
+++ b/include/http_response.cc
@@ -1,0 +1,110 @@
+#include "http_response.hh"
+
+#include <sstream>
+
+
+namespace potion {
+
+// could make this a switch statement instead, not sure which one is faster when there are a lot of cases
+const std::unordered_map<unsigned int, std::string> HttpResponse::status_code_map_ = {
+    // ** 1xx Informational **
+    { 100,       "Continue" },
+    { 101,       "Switching Protocols" },
+    { 102,       "Processing" },
+    { 103,       "Early Hints" },
+    // ** 2xx Success **
+    { 200,       "OK" },
+    { 201,       "Created" },
+    { 202,       "Accepted" },
+    { 203,       "Non-Authoritative Information" },
+    { 204,       "No Content" },
+    { 205,       "Reset Content" },
+    { 206,       "Partial Content" },
+    { 207,       "Multi-Status" },
+    { 208,       "Already Reported" },
+    { 226,       "IM Used" },
+    // ** 3xx Redirection **
+    { 300,       "Multiple Choices" },
+    { 301,       "Moved Permanently" },
+    { 302,       "Found" },
+    { 303,       "See Other" },
+    { 304,       "Not Modified" },
+    { 305,       "Use Proxy" },
+    { 307,       "Temporary Redirect" },
+    { 308,       "Permanent Redirect" },
+    // ** 4xx Client Error **
+    { 400,       "Bad Request" },
+    { 401,       "Unauthorized" },
+    { 402,       "Payment Required" },
+    { 403,       "Forbidden" },
+    { 404,       "Not Found" },
+    { 405,       "Method Not Allowed" },
+    { 406,       "Not Acceptable" },
+    { 407,       "Proxy Authentication Required" },
+    { 408,       "Request Timeout" },
+    { 409,       "Conflict" },
+    { 410,       "Gone" },
+    { 411,       "Length Required" },
+    { 412,       "Precondition Failed" },
+    { 413,       "Payload Too Large" },
+    { 414,       "URI Too Long" },
+    { 415,       "Unsupported Media Type" },
+    { 416,       "Range Not Satisfiable" },
+    { 417,       "Expectation Failed" },
+    { 418,       "I'm a teapot" },
+    { 421,       "Misdirected Request" },
+    { 422,       "Unprocessable Entity" },
+    { 423,       "Locked" },
+    { 424,       "Failed Dependency" },
+    { 426,       "Upgrade Required" },
+    { 428,       "Precondition Required" },
+    { 429,       "Too Many Requests" },
+    { 431,       "Request Header Fields Too Large" },
+    { 444,       "Connection Closed Without Response" },
+    { 451,       "Unavailable For Legal Reasons" },
+    { 499,       "Client Closed Request" },
+    // ** 5xx Server Error **
+    { 500,       "Internal Server Error" },
+    { 501,       "Not Implemented" },
+    { 502,       "Bad Gateway" },
+    { 503,       "Service Unavailable" },
+    { 504,       "Gateway Timeout" },
+    { 505,       "HTTP Version Not Supported" },
+    { 506,       "Variant Also Negotiates" },
+    { 507,       "Insufficient Storage" },
+    { 508,       "Loop Detected" },
+    { 510,       "Not Extended" },
+    { 511,       "Network Authentication Required" },
+    { 500,       "Internal Server Error" },
+    { 501,       "Not Implemented" },
+    { 502,       "Bad Gateway" },
+    { 503,       "Service Unavailable" },
+    { 504,       "Gateway Timeout" },
+    { 505,       "HTTP Version Not Supported" },
+    { 506,       "Variant Also Negotiates" },
+    { 507,       "Insufficient Storage" },
+    { 508,       "Loop Detected" },
+    { 510,       "Not Extended" },
+    { 511,       "Network Authentication Required" },
+};
+
+HttpResponse::HttpResponse(unsigned int status_code) {
+    status_code_ = status_code;
+    headers_["Content-Type"] = "text/html";
+    headers_["Content-Length"] = "0";
+}
+
+std::string HttpResponse::ToString() {
+    std::ostringstream oss;
+    oss << "HTTP/1.1 " << status_code_ << " " << status_code_map_.at(status_code_) << "\r\n";
+    for (auto& [key, value] : headers_) {
+        oss << key << ": " << value << "\r\n";
+    }
+    oss << "\r\n";
+    oss << body_;
+    return oss.str();
+}
+
+
+
+} // namespace potion

--- a/include/http_response.hh
+++ b/include/http_response.hh
@@ -1,49 +1,51 @@
 #ifndef POTION_HTTP_RESP_H
 #define POTION_HTTP_RESP_H
 
-#include <string>
 #include <map>
+#include <string>
 #include <unordered_map>
+#include <utility>
 
 namespace potion {
 
 class HttpResponse {
-public:
-// constructor
-HttpResponse(unsigned int status_code);
+   public:
+    // constructor
+    explicit HttpResponse(unsigned int status_code);
 
-// modifiers
-void set_body(std::string body) { 
-    body_ = body;
-    headers_["Content-Length"] = std::to_string(body.size());
-}
-void set_header(std::string key, std::string value) { headers_[key] = value; }
-// **TODO: add validation for content type
-void set_content_type(std::string content_type) { headers_["Content-Type"] = content_type; }
+    // modifiers
+    void set_body(const std::string& body) {
+        body_ = body;
+        headers_["Content-Length"] = std::to_string(body.size());
+    }
+    void set_header(const std::string& key, std::string value) {
+        headers_[key] = std::move(value);
+    }
+    // **TODO: add validation for content type
+    void set_content_type(std::string content_type) {
+        headers_["Content-Type"] = std::move(content_type);
+    }
 
-// accessors
-std::string body() const { return body_; }
-std::string header(const std::string& key) const { return headers_.at(key); }
-unsigned int status_code() const { return status_code_;}
+    // accessors
+    std::string body() const { return body_; }
+    std::string header(const std::string& key) const {
+        return headers_.at(key);
+    }
+    unsigned int status_code() const { return status_code_; }
 
-// convert to raw response string
-std::string ToString();
+    // convert to raw response string
+    std::string ToString();
 
-private:
+   private:
+    // response data
+    unsigned int status_code_;
+    std::string body_;
+    std::map<std::string, std::string> headers_;
 
-// response data
-unsigned int status_code_;
-std::string body_;
-std::map<std::string, std::string> headers_;
-
-
-// map of status codes to status message strings
-static const std::unordered_map<unsigned int, std::string> status_code_map_;
-
+    // map of status codes to status message strings
+    static const std::unordered_map<unsigned int, std::string> status_code_map_;
 };
 
-
-} // namespace potion
-
+}  // namespace potion
 
 #endif

--- a/include/http_response.hh
+++ b/include/http_response.hh
@@ -1,0 +1,49 @@
+#ifndef POTION_HTTP_RESP_H
+#define POTION_HTTP_RESP_H
+
+#include <string>
+#include <map>
+#include <unordered_map>
+
+namespace potion {
+
+class HttpResponse {
+public:
+// constructor
+HttpResponse(unsigned int status_code);
+
+// modifiers
+void set_body(std::string body) { 
+    body_ = body;
+    headers_["Content-Length"] = std::to_string(body.size());
+}
+void set_header(std::string key, std::string value) { headers_[key] = value; }
+// **TODO: add validation for content type
+void set_content_type(std::string content_type) { headers_["Content-Type"] = content_type; }
+
+// accessors
+std::string body() const { return body_; }
+std::string header(const std::string& key) const { return headers_.at(key); }
+unsigned int status_code() const { return status_code_;}
+
+// convert to raw response string
+std::string ToString();
+
+private:
+
+// response data
+unsigned int status_code_;
+std::string body_;
+std::map<std::string, std::string> headers_;
+
+
+// map of status codes to status message strings
+static const std::unordered_map<unsigned int, std::string> status_code_map_;
+
+};
+
+
+} // namespace potion
+
+
+#endif

--- a/include/uri.hh
+++ b/include/uri.hh
@@ -8,9 +8,9 @@ namespace potion {
 class Uri {
 public:
 
-void SetPath(const std::string& path) { path_ = path; }
-void SetHost(const std::string& host) { host_ = host; }
-void SetPort(const std::string& port) { port_ = port; }
+void set_path(const std::string& path) { path_ = path; }
+void set_host(const std::string& host) { host_ = host; }
+void set_port(const std::string& port) { port_ = port; }
 
 std::string path() const { return path_; }
 std::string host() const { return host_; }
@@ -26,6 +26,6 @@ std::string port_;
 };
 
 
-}
+} // namespace potion
 
 #endif

--- a/include/uri.hh
+++ b/include/uri.hh
@@ -6,26 +6,22 @@
 namespace potion {
 
 class Uri {
-public:
+   public:
+    void set_path(const std::string& path) { path_ = path; }
+    void set_host(const std::string& host) { host_ = host; }
+    void set_port(const std::string& port) { port_ = port; }
 
-void set_path(const std::string& path) { path_ = path; }
-void set_host(const std::string& host) { host_ = host; }
-void set_port(const std::string& port) { port_ = port; }
+    std::string path() const { return path_; }
+    std::string host() const { return host_; }
+    std::string port() const { return port_; }
+    std::string uri() const { return host_ + ":" + port_ + path_; }
 
-std::string path() const { return path_; }
-std::string host() const { return host_; }
-std::string port() const { return port_; }
-std::string uri() const { return host_ + ":" + port_ + path_;}
-
-private:
-
-std::string path_;
-std::string host_;
-std::string port_;
-
+   private:
+    std::string path_;
+    std::string host_;
+    std::string port_;
 };
 
-
-} // namespace potion
+}  // namespace potion
 
 #endif

--- a/sample_server.cc
+++ b/sample_server.cc
@@ -1,17 +1,28 @@
 #include "include/server.hh"
 #include "include/http_request.hh"
+#include "include/http_response.hh"
 
 #include <string>
+// #include <iostream>
 
 int main () {
     potion::Server app(8080);
 
     app.add_route("/test", [](potion::HttpRequest a) -> std::string {
-        return "HTTP/1.1 200 OK\nContent-Type: text/plain\n\ntest";
+        potion::HttpResponse response(200);
+        response.set_body("GG EZ");
+        response.set_content_type("text/plain");
+
+        // std::cout << response.ToString() << std::endl;
+
+        return response.ToString();
     });
 
     app.add_route("/foo", [](potion::HttpRequest a) -> std::string {
-        return "HTTP/1.1 200 OK\nContent-Type: text/plain\n\nbar";
+        potion::HttpResponse response(200);
+        response.set_body("bar");
+        response.set_header("X-Test", "test");
+        return response.ToString();
     });
 
     app.start();


### PR DESCRIPTION
idk why http response and clang stuff became one pr, prolly shoulda made these separate branches in my fork lol

http response interface todos:
- header validation (specifically content-type)
- optimizations ofc

For clang tidy/format:
- the clangd vs code extension embeds both of these so idt there's anything you need to install, disable c++ intellisense tho if you haven't alr because that might get in the way
- i think in order to get clang-tidy to work in vs code you need to add the --clang-tidy flag for clangd arguments, this is what i have:
![image](https://github.com/andyluo03/potion/assets/66141551/f016d7b7-3bef-40ec-b287-09b745db8595)
- clang-format as of now follows google format guidelines, that can change later if necessary
- clang-tidy has a bunch of checks rn, some of which probably aren't necessary, so feel free to modify the checks in the .clang-tidy file